### PR TITLE
Minor improvements to periodogram

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -810,7 +810,7 @@ class LombScarglePeriodogram(Periodogram):
                 maximum_frequency = nyquist * nyquist_factor
 
             # Create frequency grid evenly spaced in frequency
-            frequency = np.arange(minimum_frequency.value, maximum_frequency.value, fs.to(freq_unit).value)
+            frequency = np.arange(minimum_frequency.value, maximum_frequency.value, fs.value)
 
         # Convert to desired units
         frequency = u.Quantity(frequency, freq_unit)
@@ -831,11 +831,11 @@ class LombScarglePeriodogram(Periodogram):
             nterms = 1
 
         if float(astropy.__version__[0]) >= 3:
-            LS = LombScargle(time, lc.flux_quantity,
+            LS = LombScargle(time, lc.flux,
                              nterms=nterms, normalization='psd', **kwargs)
             power = LS.power(frequency, method=ls_method)
         else:
-            LS = LombScargle(time, lc.flux_quantity,
+            LS = LombScargle(time, lc.flux,
                              nterms=nterms, **kwargs)
             power = LS.power(frequency, method=ls_method, normalization='psd')
 


### PR DESCRIPTION
Hi @barentsen et al,

I've been going through `periodogram` to see if there are any changes we can make to the `from_lightcurve` method that improves the compatibility with the new Astropy Timeseries lightcurve objects. I've made a couple of minor changes in this commit, and have two other comments which I thought warranted some discussion before being changed in the code.

- The `from_lightcurve` method has a check for the `time_format` (line 760) of `lc.time` property, to ensure it is in some version of days. This is deprecated anyway, and I was wondering whether such a check was still necessary. Astropy Time objects have unit data, and so are robust against choice of units when creating the periodogram (i.e. units of seconds or hours would be equally functional). 

- When creating a lightcurve object form scratch, there is still the option to only pass `flux` data. This breaks now, as it tries to initiate an Astropy Time object without a format or scale. It will probably have to be deprecated, or some other allowance made for not including time data. 

Cheers!
Oli