### PR TITLE
fix bug in diff'ing astropy table

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -761,7 +761,7 @@ class LombScarglePeriodogram(Periodogram):
         time = lc.time.copy()
 
         # Approximate Nyquist Frequency and frequency bin width in terms of days
-        nyquist = 0.5 * (1./(np.median(np.diff(time))))
+        nyquist = 0.5 * (1./(np.median(np.diff(time.value)))) * (1/cds.d)
         fs = (1./(time[-1] - time[0])) / oversample_factor
 
         # Convert these values to requested frequency unit


### PR DESCRIPTION
Addresses bug which causes Python stall when calculating the periodogram on astropy Time objects